### PR TITLE
Add ASE support for reading CIFs

### DIFF
--- a/cif_file_ingester/parse_cif_pmg.py
+++ b/cif_file_ingester/parse_cif_pmg.py
@@ -1,5 +1,7 @@
 from pypif.obj import *
+import ase.io
 from pymatgen import Structure
+from pymatgen.io.ase import AseAtomsAdaptor
 
 def get_crystal_system(structure):
 
@@ -59,9 +61,16 @@ def parse_cif(f):
     ##### Use pymatgen to quickly obtain some information #####
     try:
         structure = Structure.from_file(f)
-    except:
-        print(f, 'is not interpretable by pymatgen')
-        return None
+    except Exception:
+        # Try with ASE instead
+        try:
+            ase_res = ase.io.read(f)
+            assert ase_res
+            # Convert ASE Atoms to Pymatgen Structure
+            structure = AseAtomsAdaptor.get_structure(ase_res)
+        except Exception:
+            print(f, 'is not interpretable by pymatgen or ase')
+            return None
 
     sg, num, bravais = get_crystal_system(structure)
     a, b, c = structure.lattice.abc

--- a/cif_file_ingester/parse_cif_pmg.py
+++ b/cif_file_ingester/parse_cif_pmg.py
@@ -65,7 +65,8 @@ def parse_cif(f):
         # Try with ASE instead
         try:
             ase_res = ase.io.read(f)
-            assert ase_res
+            if not ase_res:
+                raise ValueError("ASE retrieved no data from file")
             # Convert ASE Atoms to Pymatgen Structure
             structure = AseAtomsAdaptor.get_structure(ase_res)
         except Exception:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pypif==2.1.0
+ase
 pymatgen

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pypif==2.1.0
-ase
+ase==3.16.2
 pymatgen

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(name='cif_file_ingester',
     packages=find_packages(),
     install_requires=[
         'pypif>=2.1.0,<3',
+        'ase',
         'pymatgen'
     ],
     entry_points={

--- a/test_files/Ce3VO16.cif
+++ b/test_files/Ce3VO16.cif
@@ -1,0 +1,105 @@
+#------------------------------------------------------------------------------
+#$Date: 2016-03-02 09:51:31 +0200 (Wed, 02 Mar 2016) $
+#$Revision: 177123 $
+#$URL: svn://www.crystallography.net/cod/cif/5/91/02/5910204.cif $
+#------------------------------------------------------------------------------
+#
+# This file is available in the Crystallography Open Database (COD),
+# http://www.crystallography.net/
+#
+# All data on this site have been placed in the public domain by the
+# contributors.
+#
+data_5910204
+loop_
+_publ_author_name
+'Wyckoff, R. W. G.'
+_publ_section_title
+;
+Pages 15 & 17 from the Structure of Crystals, vol. 3 by Wyckoff R W G. 
+published by Interscience Publishers, Inc. in 1951 
+;
+_journal_name_full               'The Structure of Crystals'
+_journal_page_first              15
+_journal_page_last               17
+_journal_volume                  3
+_journal_year                    1951
+_chemical_formula_structural     CeVO4
+_chemical_formula_sum            'Ce O4 V'
+_space_group_IT_number           141
+_symmetry_cell_setting           tetragonal
+_symmetry_Int_Tables_number      141
+_symmetry_space_group_name_Hall  '-I 4bd 2'
+_symmetry_space_group_name_H-M   'I 41/a m d :2'
+_audit_creation_date             2006-30-06
+_audit_creation_method
+;
+Pages 15 & 17 from the Structure of Crystals, vol. 3 by Wyckoff R W G. 
+published by Interscience Publishers, Inc. in 1951 
+;
+_audit_update_record
+'created by Girish Upreti, Portland State University'
+_cell_angle_alpha                90
+_cell_angle_beta                 90
+_cell_angle_gamma                90
+_cell_length_a                   7.399
+_cell_length_b                   7.399
+_cell_length_c                   6.496
+_cell_volume                     355.625
+_cod_original_sg_symbol_H-M      'I 41/a m d'
+_cod_original_formula_sum        'Ce V O4'
+_cod_database_code               5910204
+loop_
+_symmetry_equiv_pos_as_xyz
+x,y,z
+-y+1/4,x+3/4,z+1/4
+y+1/4,-x+1/4,z+3/4
+x,-y,-z
+-x,y+1/2,-z
+-x,-y+1/2,z
+y+1/4,x+3/4,-z+1/4
+-y+1/4,-x+1/4,-z+3/4
+-x,-y,-z
+y+3/4,-x+1/4,-z+3/4
+-y+3/4,x+3/4,-z+1/4
+-x,y,z
+x,-y+1/2,z
+x,y+1/2,-z
+-y+3/4,-x+1/4,z+3/4
+y+3/4,x+3/4,z+1/4
+x+1/2,y+1/2,z+1/2
+-y+3/4,x+1/4,z+3/4
+y+3/4,-x+3/4,z+1/4
+x+1/2,-y+1/2,-z+1/2
+-x+1/2,y,-z+1/2
+-x+1/2,-y,z+1/2
+y+3/4,x+1/4,-z+3/4
+-y+3/4,-x+3/4,-z+1/4
+-x+1/2,-y+1/2,-z+1/2
+y+1/4,-x+3/4,-z+1/4
+-y+1/4,x+1/4,-z+3/4
+-x+1/2,y+1/2,z+1/2
+x+1/2,-y,z+1/2
+x+1/2,y,-z+1/2
+-y+1/4,-x+3/4,z+1/4
+y+1/4,x+1/4,z+3/4
+loop_
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_label
+0.00000 0.00000 0.00000 Ce1
+0.00000 0.50000 0.25000 Ce2
+0.50000 0.00000 0.75000 Ce3
+0.50000 0.50000 0.50000 Ce4
+0.00000 0.00000 0.50000 V1
+0.00000 0.50000 0.75000 V2
+0.50000 0.00000 0.25000 V3
+0.50000 0.50000 0.00000 V4
+0.00000 0.20000 0.34000 O1
+0.00000 -0.20000 0.34000 O2
+0.20000 0.00000 -0.34000 O3
+-0.20000 0.00000 -0.34000 O4
+0.00000 0.70000 -0.09000 O5
+0.00000 0.30000 -0.09000 O6
+-0.20000 0.50000 0.59000 O7

--- a/tests/test_ingester.py
+++ b/tests/test_ingester.py
@@ -45,6 +45,19 @@ def test_parse_cif():
                 if cond.name == "Radiation type":
                     assert cond.scalars[0].value == 'Mo K-$\\alpha$', 'Incorrect radiation type'
 
+    # Test ASE fallback
+    system = parse_cif('test_files/Ce3VO16.cif')
+    assert system.chemical_formula == 'Ce3VO16', 'Incorrect chemical formula'
+
+    assert len(system.properties) == 14, 'Incorrect number of properties'
+    for prop in system.properties:
+        if prop.name == "Space group symbol":
+            assert len(prop.scalars) == 1, 'Incorrect length'
+            assert prop.scalars[0].value == 'I4_1/amd', 'Incorrect property value'
+        elif prop.name == "Unit cell volume":
+            assert str(prop.scalars[0].value) == '355.625', 'Incorrect unit cell volume'
+
+
 def test_cif_converter():
     '''
     Test that correct number of PIFs are created


### PR DESCRIPTION
There exist CIFs that cannot be read by Pymatgen, but can be read by ASE (I believe some examples are in the COD, but I unfortunately don't have specific files to test). To process these files, it's possible to use ASE to read the CIF, and then convert the ASE `Atoms` object into a Pymatgen `Structure`. `parse_cif_pmg` now uses this method as a fallback when Pymatgen fails to read a CIF.